### PR TITLE
Enable saving videos to camera roll on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-media-capture",
-  "version": "3.0.2-j5.1",
+  "version": "3.0.2-j5.2",
   "description": "Cordova Media Capture Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
 xmlns:android="http://schemas.android.com/apk/res/android"
 xmlns:rim="http://www.blackberry.com/ns/widgets"
            id="cordova-plugin-media-capture"
-      version="3.0.2-j5.1">
+      version="3.0.2-j5.2">
     <name>Capture</name>
 
     <description>Cordova Media Capture Plugin</description>

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -281,13 +281,13 @@
 {
     // save the movie to photo album (only avail as of iOS 3.1)
 
-    /* don't need, it should automatically get saved
+
      NSLog(@"can save %@: %d ?", moviePath, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath));
     if (&UIVideoAtPathIsCompatibleWithSavedPhotosAlbum != NULL && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath) == YES) {
         NSLog(@"try to save movie");
         UISaveVideoAtPathToSavedPhotosAlbum(moviePath, nil, nil, nil);
         NSLog(@"finished saving movie");
-    }*/
+    }
     // create MediaFile object
     NSDictionary* fileDict = [self getMediaDictionaryFromPath:moviePath ofType:nil];
     NSArray* fileArray = [NSArray arrayWithObject:fileDict];


### PR DESCRIPTION
Jira ticket #: PT-5911
I looked into why the mobile app isn't saving videos to the camera roll and two sources (https://www.oodlestechnologies.com/blogs/store-taken-photos-and-videos-from-app-to-ios-camera-roll/; https://stackoverflow.com/questions/25719594/phonegap-ios-capture-video-not-saving-to-iphone-camera-roll) suggested uncommenting this block of code. 

I've uncommented it and now videos are saved to the camera roll. 

Tested on an iPhone 8 running iOS 14.2