### PR TITLE
Add FileProvider for Video saving

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -81,10 +81,22 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>
+        <config-file target="AndroidManifest.xml" parent="application">
+          <provider
+              android:name="org.apache.cordova.mediacapture.FileProvider"
+              android:authorities="${applicationId}.cordova.plugin.mediacapture.provider"
+              android:exported="false"
+              android:grantUriPermissions="true" >
+              <meta-data
+                  android:name="android.support.FILE_PROVIDER_PATHS"
+                  android:resource="@xml/camera_provider_paths"/>
+          </provider>
+        </config-file>
 
         <source-file src="src/android/Capture.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/PendingRequests.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/mediacapture" />
 
         <js-module src="www/android/init.js" name="init">
             <runs />

--- a/plugin.xml
+++ b/plugin.xml
@@ -89,7 +89,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
               android:grantUriPermissions="true" >
               <meta-data
                   android:name="android.support.FILE_PROVIDER_PATHS"
-                  android:resource="@xml/camera_provider_paths"/>
+                  android:resource="@xml/mediacapture_provider_paths"/>
           </provider>
         </config-file>
 
@@ -97,6 +97,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/PendingRequests.java" target-dir="src/org/apache/cordova/mediacapture" />
         <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/mediacapture" />
+        <source-file src="src/android/xml/mediacapture_provider_paths.xml" target-dir="res/xml" />
 
         <js-module src="www/android/init.js" name="init">
             <runs />

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -1,0 +1,21 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.mediacapture;
+
+public class FileProvider extends androidx.core.content.FileProvider {}

--- a/src/android/xml/mediacapture_provider_paths.xml
+++ b/src/android/xml/mediacapture_provider_paths.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache_files" path="." />
+</paths>


### PR DESCRIPTION
We need to save the Video up front in the app Storage so that we don't end up trying to move it between mounted filesystems, which android does not like. 

FileProvider is supported from a very early version of Android, and the below solution is hand-picked and modified from the Photo solution in cordova-plugin-camera

https://github.com/apache/cordova-plugin-camera/blob/9eecbaa1afc8ade7240ee6e9262781a046d2545b/src/android/CameraLauncher.java#L335