### PR TITLE
Add j5 changes to 6.0.x

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,12 @@
 -->
 # Release Notes
 
+### 6.0.0-j5.1
+
+* [#1](https://github.com/j5int/cordova-plugin-media-capture/pull/1) Fix video capture crashing on save
+* [#4](https://github.com/j5int/cordova-plugin-media-capture/pull/4) Enable saving videos to camera roll on iOS
+* [#5](https://github.com/j5int/cordova-plugin-media-capture/pull/5) Work around bug in sdk 33 - this gets the Video working on that platform
+
 ### 6.0.0 (Feb 21, 2025)
 
 **Breaking Changes:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-media-capture",
-  "version": "6.0.0",
+  "version": "6.0.0-j5.1",
   "description": "Cordova Media Capture Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-media-capture"
-      version="6.0.0">
+      version="6.0.0-j5.1">
     <name>Capture</name>
 
     <description>Cordova Media Capture Plugin</description>

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -319,18 +319,11 @@ public class Capture extends CordovaPlugin {
                 this.applicationId + ".cordova.plugin.mediacapture.provider",
                 movie);
         this.videoAbsolutePath = movie.getAbsolutePath();
-        if(Build.VERSION.SDK_INT != 33){
-               // There appears to be a bug in 33 that if we set these it doesn't call generateVideoValues()
-               // See https://android.googlesource.com/platform/packages/apps/Camera2/+/refs/heads/android13-release/src/com/android/camera/VideoModule.java
-               // VideoModule.java:1263
-               // java.lang.NullPointerException: Attempt to invoke virtual method 'void android.content.ContentValues.put(java.lang.String, java.lang.Long)' on a null object reference
-                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
-                intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
-                intent.putExtra("android.intent.extra.durationLimit", req.duration);
-                intent.putExtra("android.intent.extra.videoQuality", req.quality);
-        }
-        
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+        intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
+        intent.putExtra("android.intent.extra.durationLimit", req.duration);
+        intent.putExtra("android.intent.extra.videoQuality", req.quality);
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
     }
 

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -319,11 +319,18 @@ public class Capture extends CordovaPlugin {
                 this.applicationId + ".cordova.plugin.mediacapture.provider",
                 movie);
         this.videoAbsolutePath = movie.getAbsolutePath();
-        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
-        intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
-        intent.putExtra("android.intent.extra.durationLimit", req.duration);
-        intent.putExtra("android.intent.extra.videoQuality", req.quality);
+        if(Build.VERSION.SDK_INT != 33){
+               // There appears to be a bug in 33 that if we set these it doesn't call generateVideoValues()
+               // See https://android.googlesource.com/platform/packages/apps/Camera2/+/refs/heads/android13-release/src/com/android/camera/VideoModule.java
+               // VideoModule.java:1263
+               // java.lang.NullPointerException: Attempt to invoke virtual method 'void android.content.ContentValues.put(java.lang.String, java.lang.Long)' on a null object reference
+                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+                intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
+                intent.putExtra("android.intent.extra.durationLimit", req.duration);
+                intent.putExtra("android.intent.extra.videoQuality", req.quality);
+        }
+        
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
     }
 

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -57,6 +57,8 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.system.Os;
 import android.system.OsConstants;
+import android.database.Cursor;
+import android.provider.MediaStore;
 
 public class Capture extends CordovaPlugin {
 
@@ -318,12 +320,20 @@ public class Capture extends CordovaPlugin {
         Uri videoUri = FileProvider.getUriForFile(this.cordova.getActivity(),
                 this.applicationId + ".cordova.plugin.mediacapture.provider",
                 movie);
-        this.videoAbsolutePath = movie.getAbsolutePath();
-        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+        this.videoAbsolutePath = movie.getAbsolutePath();        
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
-        intent.putExtra("android.intent.extra.durationLimit", req.duration);
-        intent.putExtra("android.intent.extra.videoQuality", req.quality);
+
+        if(Build.VERSION.SDK_INT != 33){
+               // There appears to be a bug in 33 that if we set these it doesn't call generateVideoValues()
+               // See https://android.googlesource.com/platform/packages/apps/Camera2/+/refs/heads/android13-release/src/com/android/camera/VideoModule.java
+               // VideoModule.java:1263
+               // java.lang.NullPointerException: Attempt to invoke virtual method 'void android.content.ContentValues.put(java.lang.String, java.lang.Long)' on a null object reference
+                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+                intent.putExtra("android.intent.extra.durationLimit", req.duration);
+                intent.putExtra("android.intent.extra.videoQuality", req.quality);
+        }
+
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
     }
 
@@ -352,7 +362,7 @@ public class Capture extends CordovaPlugin {
                             onImageActivityResult(req);
                             break;
                         case CAPTURE_VIDEO:
-                            onVideoActivityResult(req);
+                            onVideoActivityResult(req, intent);
                             break;
                     }
                 }
@@ -457,8 +467,39 @@ public class Capture extends CordovaPlugin {
         }
     }
 
-    public void onVideoActivityResult(Request req) {
+    public String getRealPathFromURI(Uri uri) {
+       String filePath = null;
+       if ("content".equalsIgnoreCase(uri.getScheme())) {
+           String[] projection = { MediaStore.Images.Media.DATA };
+           Cursor cursor = null;
+           try {
+               cursor = cordova.getActivity().getContentResolver().query(uri, projection, null, null, null);
+               if (cursor != null && cursor.moveToFirst()) {
+                   int index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+                   filePath = cursor.getString(index);
+               }
+           } finally {
+               if (cursor != null) {
+                   cursor.close();
+               }
+           }
+       } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+           filePath = uri.getPath();
+       }
+       return filePath;
+   }
+
+
+    public void onVideoActivityResult(Request req, Intent intent) {
         try {
+            // For Android 13, retrieve the video URI from the intent if EXTRA_OUTPUT was not set
+            if (Build.VERSION.SDK_INT == 33 && intent != null && intent.getData() != null) {
+                Uri videoUri = intent.getData();
+                this.videoAbsolutePath = getRealPathFromURI(videoUri);
+                System.out.println("URI: " + videoUri);
+                System.out.println("PATH: " + this.videoAbsolutePath);
+            }
+           
             // create a file object from the video absolute path
             JSONObject mediaFile = createMediaFileWithAbsolutePath(this.videoAbsolutePath);
             if (mediaFile == null) {

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -458,21 +458,25 @@ public class Capture extends CordovaPlugin {
     }
 
     public void onVideoActivityResult(Request req) {
-        // create a file object from the video absolute path
-        JSONObject mediaFile = createMediaFileWithAbsolutePath(this.videoAbsolutePath);
-        if (mediaFile == null) {
-            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + this.videoAbsolutePath));
-            return;
-        }
+        try {
+            // create a file object from the video absolute path
+            JSONObject mediaFile = createMediaFileWithAbsolutePath(this.videoAbsolutePath);
+            if (mediaFile == null) {
+                pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + this.videoAbsolutePath));
+                return;
+            }
 
-        req.results.put(mediaFile);
+            req.results.put(mediaFile);
 
-        if (req.results.length() >= req.limit) {
-            // Send Uri back to JavaScript for viewing video
-            pendingRequests.resolveWithSuccess(req);
-        } else {
-            // still need to capture more video clips
-            captureVideo(req);
+            if (req.results.length() >= req.limit) {
+                // Send Uri back to JavaScript for viewing video
+                pendingRequests.resolveWithSuccess(req);
+            } else {
+                // still need to capture more video clips
+                captureVideo(req);
+            }
+        } catch (Exception e) {
+            LOG.e(LOG_TAG, e.getMessage());
         }
     }
 

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -57,8 +57,6 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.system.Os;
 import android.system.OsConstants;
-import android.database.Cursor;
-import android.provider.MediaStore;
 
 public class Capture extends CordovaPlugin {
 
@@ -321,19 +319,11 @@ public class Capture extends CordovaPlugin {
                 this.applicationId + ".cordova.plugin.mediacapture.provider",
                 movie);
         this.videoAbsolutePath = movie.getAbsolutePath();        
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
-
-        if(Build.VERSION.SDK_INT != 33){
-               // There appears to be a bug in 33 that if we set these it doesn't call generateVideoValues()
-               // See https://android.googlesource.com/platform/packages/apps/Camera2/+/refs/heads/android13-release/src/com/android/camera/VideoModule.java
-               // VideoModule.java:1263
-               // java.lang.NullPointerException: Attempt to invoke virtual method 'void android.content.ContentValues.put(java.lang.String, java.lang.Long)' on a null object reference
-                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
-                intent.putExtra("android.intent.extra.durationLimit", req.duration);
-                intent.putExtra("android.intent.extra.videoQuality", req.quality);
-        }
-
+        LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);        
+        intent.putExtra("android.intent.extra.durationLimit", req.duration);
+        intent.putExtra("android.intent.extra.videoQuality", req.quality);
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
     }
 
@@ -362,7 +352,7 @@ public class Capture extends CordovaPlugin {
                             onImageActivityResult(req);
                             break;
                         case CAPTURE_VIDEO:
-                            onVideoActivityResult(req, intent);
+                            onVideoActivityResult(req);
                             break;
                     }
                 }
@@ -467,37 +457,8 @@ public class Capture extends CordovaPlugin {
         }
     }
 
-    public String getRealPathFromURI(Uri uri) {
-       String filePath = null;
-       if ("content".equalsIgnoreCase(uri.getScheme())) {
-           String[] projection = { MediaStore.Images.Media.DATA };
-           Cursor cursor = null;
-           try {
-               cursor = cordova.getActivity().getContentResolver().query(uri, projection, null, null, null);
-               if (cursor != null && cursor.moveToFirst()) {
-                   int index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
-                   filePath = cursor.getString(index);
-               }
-           } finally {
-               if (cursor != null) {
-                   cursor.close();
-               }
-           }
-       } else if ("file".equalsIgnoreCase(uri.getScheme())) {
-           filePath = uri.getPath();
-       }
-       return filePath;
-   }
-
-
-    public void onVideoActivityResult(Request req, Intent intent) {
+    public void onVideoActivityResult(Request req) {
         try {
-            // For Android 13, retrieve the video URI from the intent if EXTRA_OUTPUT was not set
-            if (Build.VERSION.SDK_INT == 33 && intent != null && intent.getData() != null) {
-                Uri videoUri = intent.getData();
-                this.videoAbsolutePath = getRealPathFromURI(videoUri);
-            }
-           
             // create a file object from the video absolute path
             JSONObject mediaFile = createMediaFileWithAbsolutePath(this.videoAbsolutePath);
             if (mediaFile == null) {

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -496,8 +496,6 @@ public class Capture extends CordovaPlugin {
             if (Build.VERSION.SDK_INT == 33 && intent != null && intent.getData() != null) {
                 Uri videoUri = intent.getData();
                 this.videoAbsolutePath = getRealPathFromURI(videoUri);
-                System.out.println("URI: " + videoUri);
-                System.out.println("PATH: " + this.videoAbsolutePath);
             }
            
             // create a file object from the video absolute path

--- a/src/ios/CDVCapture.m
+++ b/src/ios/CDVCapture.m
@@ -293,13 +293,13 @@
 {
     // save the movie to photo album (only avail as of iOS 3.1)
 
-    /* don't need, it should automatically get saved
+
      NSLog(@"can save %@: %d ?", moviePath, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath));
     if (&UIVideoAtPathIsCompatibleWithSavedPhotosAlbum != NULL && UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(moviePath) == YES) {
         NSLog(@"try to save movie");
         UISaveVideoAtPathToSavedPhotosAlbum(moviePath, nil, nil, nil);
         NSLog(@"finished saving movie");
-    }*/
+    }
     // create MediaFile object
     NSDictionary* fileDict = [self getMediaDictionaryFromPath:moviePath ofType:nil];
     NSArray* fileArray = [NSArray arrayWithObject:fileDict];

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-media-capture-tests",
-  "version": "6.0.0",
+  "version": "6.0.0-j5.1",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-media-capture-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-media-capture-tests"
-    version="6.0.0">
+    version="6.0.0-j5.1">
     <name>Cordova Media Capture Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android/iOS

### Motivation and Context
This upgrades our fork to 6.0.x so that the photo and video permissions are no longer used in compliance with the new Google Play Store policy. It also applies the code from our patches that is still relevant with the new version of the plugin.

The changes from https://github.com/j5int/cordova-plugin-media-capture/pull/6, except for the removal of the sdk 33 if clause, were not added as they are included in https://github.com/apache/cordova-plugin-media-capture/pull/302/.

The changes to fix the issue on Android 13 were removed since it was discovered that it is only an issue on the emulator.

### Testing
This was tested with https://github.com/j5int/cordova-plugin-camera/pull/3 and https://github.com/j5int/cordova-plugin-file/pull/12.

Tested that photo and video attachments can still be added to an operation logbook IndustraForm. Also confirmed that j5 Mobile no longer has Photo and Video permissions in the Android settings.




