### PR TITLE
Get correct path for video in android 13

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -57,6 +57,8 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.system.Os;
 import android.system.OsConstants;
+import android.database.Cursor;
+import android.provider.MediaStore;
 
 public class Capture extends CordovaPlugin {
 
@@ -318,12 +320,20 @@ public class Capture extends CordovaPlugin {
         Uri videoUri = FileProvider.getUriForFile(this.cordova.getActivity(),
                 this.applicationId + ".cordova.plugin.mediacapture.provider",
                 movie);
-        this.videoAbsolutePath = movie.getAbsolutePath();
-        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+        this.videoAbsolutePath = movie.getAbsolutePath();        
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
         LOG.d(LOG_TAG, "Recording a video and saving to: " + this.videoAbsolutePath);
-        intent.putExtra("android.intent.extra.durationLimit", req.duration);
-        intent.putExtra("android.intent.extra.videoQuality", req.quality);
+
+        if(Build.VERSION.SDK_INT != 33){
+               // There appears to be a bug in 33 that if we set these it doesn't call generateVideoValues()
+               // See https://android.googlesource.com/platform/packages/apps/Camera2/+/refs/heads/android13-release/src/com/android/camera/VideoModule.java
+               // VideoModule.java:1263
+               // java.lang.NullPointerException: Attempt to invoke virtual method 'void android.content.ContentValues.put(java.lang.String, java.lang.Long)' on a null object reference
+                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, videoUri);
+                intent.putExtra("android.intent.extra.durationLimit", req.duration);
+                intent.putExtra("android.intent.extra.videoQuality", req.quality);
+        }
+
         this.cordova.startActivityForResult((CordovaPlugin) this, intent, req.requestCode);
     }
 
@@ -352,7 +362,7 @@ public class Capture extends CordovaPlugin {
                             onImageActivityResult(req);
                             break;
                         case CAPTURE_VIDEO:
-                            onVideoActivityResult(req);
+                            onVideoActivityResult(req, intent);
                             break;
                     }
                 }
@@ -457,8 +467,39 @@ public class Capture extends CordovaPlugin {
         }
     }
 
-    public void onVideoActivityResult(Request req) {
+    public String getRealPathFromURI(Uri uri) {
+       String filePath = null;
+       if ("content".equalsIgnoreCase(uri.getScheme())) {
+           String[] projection = { MediaStore.Images.Media.DATA };
+           Cursor cursor = null;
+           try {
+               cursor = cordova.getActivity().getContentResolver().query(uri, projection, null, null, null);
+               if (cursor != null && cursor.moveToFirst()) {
+                   int index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+                   filePath = cursor.getString(index);
+               }
+           } finally {
+               if (cursor != null) {
+                   cursor.close();
+               }
+           }
+       } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+           filePath = uri.getPath();
+       }
+       return filePath;
+   }
+
+
+    public void onVideoActivityResult(Request req, Intent intent) {
         try {
+            // For Android 13, retrieve the video URI from the intent if EXTRA_OUTPUT was not set
+            if (Build.VERSION.SDK_INT == 33 && intent != null && intent.getData() != null) {
+                Uri videoUri = intent.getData();
+                this.videoAbsolutePath = getRealPathFromURI(videoUri);
+                System.out.println("URI: " + videoUri);
+                System.out.println("PATH: " + this.videoAbsolutePath);
+            }
+           
             // create a file object from the video absolute path
             JSONObject mediaFile = createMediaFileWithAbsolutePath(this.videoAbsolutePath);
             if (mediaFile == null) {

--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -496,8 +496,6 @@ public class Capture extends CordovaPlugin {
             if (Build.VERSION.SDK_INT == 33 && intent != null && intent.getData() != null) {
                 Uri videoUri = intent.getData();
                 this.videoAbsolutePath = getRealPathFromURI(videoUri);
-                System.out.println("URI: " + videoUri);
-                System.out.println("PATH: " + this.videoAbsolutePath);
             }
            
             // create a file object from the video absolute path


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Description
Included the SDK 33 check from #5 and get correct video path from intent when on Android 13. This resolves an issue where taking a video and saving it does not result in the video being attached to the form.



### Testing
<!-- Please describe in detail how you tested your changes. -->
1. On an operations logbook IndustraForm, click the plus button to add an attachment.
2. Select the video option
3. If asked, allow j5 Mobile to take pictures and record video
4. Take a video and save
5. Before changes: the video would not save and display as an attachment on the form.
   After changes: the video is attached to the form

